### PR TITLE
add cpu dockerfile for the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ For docker deployment, see the sample dockerfiles in the docker directory.
 Docker for ubuntu can be tested with the following commands.
 
 ```bash
-docker build -t extensor -f docker/ubuntu.dockerfile .
+docker build -t extensor -f docker/ubuntu-cpu.dockerfile .
 docker run --rm -it extensor mix test
 ```
 
-If you have nvidia tools installed, you can test on the GPU by substituting
-`nvidia-docker` for `docker` above.
+If you have nvidia tools installed, you can test on the GPU by using the
+`ubuntu-gpu.dockerfile` and substituting `nvidia-docker` for `docker` above.
 
 ## Usage
 For a simple example, Extensor can be used to evaluate the Pythagorean

--- a/docker/ubuntu-cpu.dockerfile
+++ b/docker/ubuntu-cpu.dockerfile
@@ -1,0 +1,31 @@
+FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
+
+# install packages
+RUN apt-get update -qq && apt-get install -y \
+      build-essential curl locales
+
+# install tensorflow
+RUN curl -L https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-cpu-linux-x86_64-1.8.0.tar.gz | \
+      tar -C /usr/local -xz
+
+# install elixir
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+RUN curl https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb > /tmp/erlang-solutions_1.0_all.deb && \
+    dpkg -i /tmp/erlang-solutions_1.0_all.deb && \
+    apt-get update -qq && apt-get install -y esl-erlang elixir && \
+    mix local.rebar --force && \
+    mix local.hex --force
+
+ADD mix.exs .
+ADD c_src ./c_src
+ADD lib ./lib
+ADD test ./test
+RUN mkdir priv
+RUN mix deps.get
+RUN mix compile
+
+CMD ["iex", "-S", "mix"]

--- a/docker/ubuntu-gpu.dockerfile
+++ b/docker/ubuntu-gpu.dockerfile
@@ -26,5 +26,6 @@ ADD lib ./lib
 ADD test ./test
 RUN mkdir priv
 RUN mix deps.get
+RUN mix compile
 
 CMD ["iex", "-S", "mix"]


### PR DESCRIPTION
The sample dockerfile used in the readme only works with tensorflow-gpu. These changes allow the example to be run on osx.