### PR TITLE
add the tensor name to missing tensor errors

### DIFF
--- a/c_src/tf.cpp
+++ b/c_src/tf.cpp
@@ -451,7 +451,8 @@ void erl2tf_input(
    // configure the tensor input
    TF_Operation* op = CHECK(
       TF_GraphOperationByName(graph, key_str),
-      "tensor_not_found");
+      "tensor_not_found",
+      key_str);
    config[index].oper  = op;
    config[index].index = op_index;
 }
@@ -491,7 +492,8 @@ void erl2tf_outputs(
       // configure the tensor output
       TF_Operation* op = CHECK(
          TF_GraphOperationByName(graph, name_str),
-         "tensor_not_found");
+         "tensor_not_found",
+         name_str);
       config[i].oper  = op;
       config[i].index = op_index;
       // configure the operation to execute


### PR DESCRIPTION
This fixes issue #4. The tensor name is now included in the tensor not found error tuple. The session tests have also been modified to check error codes/messages.