### PR TITLE
isolate Matrex integration for true optionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,14 +184,14 @@ a = Matrex.new([[3, 5], [7, 9]])
 b = Matrex.new([[4, 12], [24, 40]])
 
 input = %{
-  "a" => Extensor.Tensor.from_matrix(a),
-  "b" => Extensor.Tensor.from_matrix(b)
+  "a" => Extensor.Matrex.to_tensor(a),
+  "b" => Extensor.Matrex.to_tensor(b)
 }
 
 session = Extensor.Session.load_frozen_graph!("test/data/pythagoras.pb")
 output = Extensor.Session.run!(session, input, ["c"])
 
-output |> Map.get("c") |> Extensor.Tensor.to_matrix()
+output |> Map.get("c") |> Extensor.Matrex.from_tensor()
 ```
 
 This block should output a 2x2 matrix, which corresponds to the

--- a/lib/extensor/matrex.ex
+++ b/lib/extensor/matrex.ex
@@ -1,0 +1,52 @@
+if Code.ensure_loaded?(Matrex) do
+  defmodule Extensor.Matrex do
+    @moduledoc """
+    Optional `Matrex` integration
+    """
+
+    alias Extensor.Tensor
+
+    @doc """
+    Convert a `Matrex` matrix to a tensor struct
+    """
+    @spec to_tensor(matrix :: Matrex.t()) :: Tensor.t()
+    def to_tensor(%Matrex{
+          data:
+            <<rows::unsigned-integer-little-32,
+              cols::unsigned-integer-little-32, body::binary>>
+        }) do
+      %Tensor{
+        type: :float,
+        shape: {rows, cols},
+        data: body
+      }
+    end
+
+    @doc """
+    Convert from an `Tensor` struct to a `Matrex` matrix
+
+    Currently, this only works for two dimensional tensors and the type _must be_
+    `:float`.
+    """
+    @spec from_tensor(tensor :: Tensor.t()) :: Matrex.t()
+    def from_tensor(tensor) do
+      cond do
+        tensor.type != :float ->
+          raise ArgumentError, "invalid tensor type: #{tensor.type}"
+
+        tuple_size(tensor.shape) != 2 ->
+          raise ArgumentError,
+                "invalid tensor shape: #{tuple_size(tensor.shape)}"
+
+        true ->
+          {r, c} = tensor.shape
+
+          %Matrex{
+            data:
+              <<r::unsigned-integer-little-32>> <>
+                <<c::unsigned-integer-little-32>> <> tensor.data
+          }
+      end
+    end
+  end
+end

--- a/lib/extensor/tensor.ex
+++ b/lib/extensor/tensor.ex
@@ -230,47 +230,4 @@ defmodule Extensor.Tensor do
 
     :ok
   end
-
-  @doc """
-  Convert a `Matrex` matrix to a tensor struct
-  """
-  @spec from_matrix(matrix :: Matrex.t()) :: t()
-  def from_matrix(%Matrex{
-        data:
-          <<rows::unsigned-integer-little-32,
-            cols::unsigned-integer-little-32, body::binary>>
-      }) do
-    %__MODULE__{
-      type: :float,
-      shape: {rows, cols},
-      data: body
-    }
-  end
-
-  @doc """
-  Convert from a tensor struct to a `Matrex` matrix
-
-  Currently, this only works for two dimensional tensors and the type _must be_
-  `:float`.
-  """
-  @spec to_matrix(tensor :: t()) :: Matrex.t()
-  def to_matrix(tensor) do
-    cond do
-      tensor.type != :float ->
-        raise ArgumentError, "invalid tensor type: #{tensor.type}"
-
-      tuple_size(tensor.shape) != 2 ->
-        raise ArgumentError,
-              "invalid tensor shape: #{tuple_size(tensor.shape)}"
-
-      true ->
-        {r, c} = tensor.shape
-
-        %Matrex{
-          data:
-            <<r::unsigned-integer-little-32, c::unsigned-integer-little-32>> <>
-              tensor.data
-        }
-    end
-  end
 end

--- a/test/extensor/matrex_test.exs
+++ b/test/extensor/matrex_test.exs
@@ -1,0 +1,37 @@
+defmodule Extensor.MatrexTest do
+  use ExUnit.Case, async: true
+
+  alias Extensor.Matrex, as: ExtensorMatrex
+  alias Extensor.Tensor
+
+  describe "matrix conversion" do
+    test "to_tensor/1" do
+      lol = [[1, 2], [3, 4]]
+
+      # converting to a tensor
+      assert Tensor.from_list(lol, :float) ==
+               lol |> Matrex.new() |> ExtensorMatrex.to_tensor()
+    end
+
+    test "from_tensor/1" do
+      lol = [[1, 2], [3, 4]]
+
+      # converting back to a matrix
+      assert Matrex.new(lol) ==
+               lol |> Tensor.from_list(:float) |> ExtensorMatrex.from_tensor()
+
+      # invalid type
+      assert_raise(ArgumentError, fn ->
+        lol |> Tensor.from_list(:double) |> ExtensorMatrex.from_tensor()
+      end)
+
+      # invalid shape
+      assert_raise(ArgumentError, fn ->
+        lol
+        |> List.first()
+        |> Tensor.from_list(:float)
+        |> ExtensorMatrex.from_tensor()
+      end)
+    end
+  end
+end

--- a/test/extensor/tensor_test.exs
+++ b/test/extensor/tensor_test.exs
@@ -85,32 +85,4 @@ defmodule Extensor.TensorTest do
       Tensor.validate!(Tensor.from_list([[1, 2], [3]]))
     end
   end
-
-  describe "matrix conversion" do
-    test "from_matrix/1" do
-      lol = [[1, 2], [3, 4]]
-
-      # converting from a matrix
-      assert Tensor.from_list(lol, :float) ==
-               lol |> Matrex.new() |> Tensor.from_matrix()
-    end
-
-    test "to_matrix/1" do
-      lol = [[1, 2], [3, 4]]
-
-      # round tripping to a matrix
-      assert Matrex.new(lol) ==
-               lol |> Tensor.from_list(:float) |> Tensor.to_matrix()
-
-      # invalid type
-      assert_raise(ArgumentError, fn ->
-        lol |> Tensor.from_list(:double) |> Tensor.to_matrix()
-      end)
-
-      # invalid shape
-      assert_raise(ArgumentError, fn ->
-        lol |> List.first() |> Tensor.from_list(:float) |> Tensor.to_matrix()
-      end)
-    end
-  end
 end


### PR DESCRIPTION
Thanks to @brentspell for pointing out that the optional dependency's code has to be isolated properly. While it could've been left in place in `Extensor.Tensor` and wrapped in the same if statement, this does feel cleaner.