### PR TITLE
add support for TF_LoadLibrary

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -13,7 +13,7 @@ clean:
 
 rebuild: clean all
 
-$(OUTDIR)/extensor.so: init.cpp tf.cpp
+$(OUTDIR)/extensor.so: extensor.cpp tf.cpp
 
 %.so:
 	mkdir -p $(dir $@)

--- a/c_src/extensor.cpp
+++ b/c_src/extensor.cpp
@@ -18,12 +18,14 @@
 extern int nif_tf_init (ErlNifEnv* env);
 /*-------------------[        Module Variables         ]-------------------*/
 /*-------------------[        Module Prototypes        ]-------------------*/
+DECLARE_NIF(tf_load_library);
 DECLARE_NIF(tf_parse_frozen_graph);
 DECLARE_NIF(tf_load_saved_model);
 DECLARE_NIF(tf_run_session);
 /*-------------------[         Implementation          ]-------------------*/
 // nif function table
 static ErlNifFunc nif_map[] = {
+   EXPORT_NIF(tf_load_library, 1),
    EXPORT_NIF(tf_parse_frozen_graph, 2, ERL_NIF_DIRTY_JOB_CPU_BOUND),
    EXPORT_NIF(tf_load_saved_model, 3, ERL_NIF_DIRTY_JOB_IO_BOUND),
    EXPORT_NIF(tf_run_session, 3, ERL_NIF_DIRTY_JOB_IO_BOUND),

--- a/lib/extensor/nif.ex
+++ b/lib/extensor/nif.ex
@@ -17,6 +17,12 @@ defmodule Extensor.NIF do
     end
   end
 
+  @doc "loads a custom op kernel library"
+  @spec tf_load_library(name :: String.t()) :: :ok
+  def tf_load_library(_name) do
+    :erlang.nif_error(:nif_library_not_loaded)
+  end
+
   @doc "loads a graph_def protobuf into a new tensorflow session"
   @spec tf_parse_frozen_graph(graph_pb :: binary(), config_pb :: binary()) ::
           reference()

--- a/lib/extensor/session.ex
+++ b/lib/extensor/session.ex
@@ -88,6 +88,21 @@ defmodule Extensor.Session do
 
   @tft2atom Map.new(@atom2tft, fn {k, v} -> {v, k} end)
 
+  @doc "loads a custom op kernel library"
+  @spec load_library(name :: String.t()) :: :ok | {:error, any()}
+  def load_library(name) do
+    load_library!(name)
+    :ok
+  rescue
+    e -> {:error, e}
+  end
+
+  @doc "loads a custom op kernel library"
+  @spec load_library!(name :: String.t()) :: :ok
+  def load_library!(name) do
+    NIF.tf_load_library(name)
+  end
+
   @doc "loads a graph_def from a file path"
   @spec load_frozen_graph(
           path :: String.t(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Extensor.MixProject do
     [
       app: :extensor,
       name: "Extensor",
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.6",
       compilers: [:elixir_make] ++ Mix.compilers(),
       make_cwd: "c_src",

--- a/test/extensor/session_test.exs
+++ b/test/extensor/session_test.exs
@@ -11,6 +11,18 @@ defmodule Extensor.SessionTest do
     {:ok, []}
   end
 
+  test "custom op kernel library" do
+    # smoke test only, building a test kernel is outside extensor's scope
+    {:error, _e} = Session.load_library("invalid")
+
+    assert_raise ErlangError, ~r/tf_error/, fn ->
+      Session.load_library!("invalid")
+    end
+
+    :ok = Session.load_library("libtensorflow.so")
+    Session.load_library!("libtensorflow.so")
+  end
+
   test "parse frozen graph" do
     config = %{
       ConfigProto.new()


### PR DESCRIPTION
This fixes #13 by adding support for loading libraries containing custom tensorflow op kernels.