### PR TITLE
warnings as errors

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,6 +1,7 @@
 ERLANG_PATH ?= $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version)])])' -s init stop -noshell)
 CC           = g++
-CFLAGS       = -Wall -O3 -fpic -Wl,-undefined,dynamic_lookup -shared \
+CFLAGS       = -std=c++11 -Wall -Werror -O3 -fpic \
+               -Wl,-undefined,dynamic_lookup -shared \
                -I$(ERLANG_PATH)/include -L$(ERLANG_PATH)/lib
 LIBS         = -ltensorflow
 OBJDIR       = ../obj

--- a/c_src/extensor.hpp
+++ b/c_src/extensor.hpp
@@ -14,7 +14,12 @@
 /*-------------------[      Project Include Files      ]-------------------*/
 /*-------------------[      Macros/Constants/Types     ]-------------------*/
 #define CHECK(result, ...)                                                 \
-   ((result) ?: (throw NifError(__VA_ARGS__)))
+   ({                                                                      \
+      auto r = (result);                                                   \
+      if (!r)                                                              \
+         throw NifError(__VA_ARGS__);                                      \
+      r;                                                                   \
+   })
 #define CHECKALLOC(result)                                                 \
    CHECK(result, "alloc_failed");
 /*-------------------[             Classes             ]-------------------*/


### PR DESCRIPTION
Remove use of the elvis operator and enable warnings as errors for gcc.