### PR TITLE
fix byte size for half dtype

### DIFF
--- a/lib/extensor/tensor.ex
+++ b/lib/extensor/tensor.ex
@@ -115,7 +115,7 @@ defmodule Extensor.Tensor do
     quint16: 2,
     uint16: 2,
     complex128: 32,
-    half: 16,
+    half: 2,
     resource: nil,
     variant: nil,
     uint32: 4,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Extensor.MixProject do
     [
       app: :extensor,
       name: "Extensor",
-      version: "1.14.0",
+      version: "1.14.1",
       elixir: "~> 1.7",
       compilers: [:elixir_make] ++ Mix.compilers(),
       make_cwd: "c_src",

--- a/test/extensor/session_test.exs
+++ b/test/extensor/session_test.exs
@@ -19,8 +19,8 @@ defmodule Extensor.SessionTest do
       Session.load_library!("invalid")
     end
 
-    :ok = Session.load_library("libtensorflow.so")
-    Session.load_library!("libtensorflow.so")
+    :ok = Session.load_library("priv/extensor.so")
+    Session.load_library!("priv/extensor.so")
   end
 
   test "parse frozen graph" do


### PR DESCRIPTION
The Tensorflow half data type is 16 bits, not 16 bytes wide. I also threw in a fix here for a clean install of libtensorflow on macos, where the linux .so files are not copied.