### PR TITLE
fix memory leak in tensorflow metagraph

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Extensor.MixProject do
     [
       app: :extensor,
       name: "Extensor",
-      version: "2.3.2",
+      version: "2.7.0",
       elixir: "~> 1.10",
       compilers: [:elixir_make] ++ Mix.compilers(),
       make_cwd: "c_src",


### PR DESCRIPTION
This change fixes a memory leak when loading saved models. The leak is caused by an incorrect assumption that the tensorflow session owns the metagraph protobuf, when the protobuf returned by `TF_LoadSessionFromSavedModel` is assumed to be owned by the caller. The metagraph protobuf is now constructed on the heap and properly released with `TF_DeleteBuffer`.